### PR TITLE
Update ZEN77 to also include ZEN72

### DIFF
--- a/ZEN77 S2 Dimmer.yaml
+++ b/ZEN77 S2 Dimmer.yaml
@@ -25,9 +25,13 @@ blueprint:
         Note that the "Scene Control" parameter will be enabled on this device (triggered by it coming online).
       selector:
         device:
-          integration: zwave_js
-          manufacturer: Zooz
-          model: ZEN77
+          entity:
+            - integration: zwave_js
+          filter:
+            - manufacturer: Zooz
+              model: ZEN72
+            - manufacturer: Zooz
+              model: ZEN77
           multiple: false
 
     local_control:


### PR DESCRIPTION
As far as I know these switches have all the same controls, but slightly different electrical details. From an automation perspective there doesn't seem to be any meaningful difference.